### PR TITLE
ci: ajout d'une Github Action pour assign automatiquement l'auteur

### DIFF
--- a/.github/auto_add_assignees.yml
+++ b/.github/auto_add_assignees.yml
@@ -1,0 +1,11 @@
+# Configuration file for https://github.com/kentaro-m/auto-assign-action
+
+# Not configured yet
+addReviewers: false
+
+# Set to true to add assignees to pull requests
+# Set to 'author' to set the PR creator as the assignee
+addAssignees: author
+
+# Set to true to run on draft pull requests
+runOnDraft: true

--- a/.github/workflows/auto-assign-pr.yml
+++ b/.github/workflows/auto-assign-pr.yml
@@ -1,0 +1,17 @@
+name: PR Auto Assignee (author)
+
+on:
+  pull_request:
+    types:
+      - opened
+      - ready_for_review
+      - reopened
+
+jobs:
+  add-assignee:
+    name: "PR: add assignee (author)"
+    runs-on: ubuntu-slim
+    steps:
+      - uses: kentaro-m/auto-assign-action@v2.0.0
+        with:
+          configuration-path: .github/auto_add_assignees.yml


### PR DESCRIPTION
### Quoi ?

https://github.com/kentaro-m/auto-assign-action

### Pourquoi ?

Retrouver plus facilement qui a fait quoi.
Cette Github Action permet aussi de définir une liste de reviewer (pas configuré)